### PR TITLE
Allow for Docker version to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # ansible-role-install-docker
-Install Docker
+
+Install Docker from upstream Docker RPM repository. Allows for installation of
+latest Docker version in repository, or (default) a pinned Docker version.
+Primarily used in 
+[kube-centos-ansible](https://github.com/redhat-nfvpe/kube-centos-ansible).
+
+## Role Variables
+
+Available variables listed below along with their default values (see
+`defaults/main.yml`):
+
+```
+docker_engine_base_name: docker-engine
+docker_engine_version: 17.03.1.ce
+```
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```
+- hosts: docker_host
+  become: true
+  become_user: root
+
+  roles:
+    - { role: install-docker, docker_engine_version: latest }
+```
+
+## Testing
+
+You can locally test a deployment of this role using
+[provision_docker](https://github.com/chrismeyersfsu/provision_docker).
+
+```
+cd tests/
+ansible-playbook test.yml
+```
+
+## License
+
+Apache v2.0
+
+## Author Information
+
+This role was created in 2017 by the
+[Red Hat NFVPE Team](https://github.com/redhat-nfvpe).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+docker_engine_version: 17.03.1.ce
+docker_engine_base_name: docker-engine

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,15 +3,21 @@
   package:
     name: libselinux-python
     state: present
+  when: testing is not defined and not testing
 
 - name: Create Docker repo
   copy:
     src: docker.repo
     dest: /etc/yum.repos.d/docker.repo
 
+- name: Setup Docker name and version to install
+  set_fact:
+    docker_engine_package: >
+      {% if docker_engine_version == 'latest' %}{{ docker_engine_base_name }}{% else %}{{ docker_engine_base_name }}-{{ docker_engine_version }}{% endif %}
+
 - name: Install docker
   package:
-    name: docker-engine
+    name: "{{ docker_engine_package }}"
     state: present
 
 - name: Create docker service systemd overrides
@@ -43,3 +49,4 @@
     name: docker.service
     state: started
     enabled: yes
+  when: testing is not defined and not testing

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+host_key_checking = False
+retry_files_enabled = False
+ansible_python_interpreter = python
+
+[paramiko_connection]
+record_host_keys = False
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,2 @@
+- src: chrismeyersfsu.provision_docker
+  name: provision_docker

--- a/tests/roles/install-docker
+++ b/tests/roles/install-docker
@@ -1,0 +1,1 @@
+../../../ansible-role-install-docker/

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,29 @@
+---
+- name: Bring up docker containers
+  hosts: localhost
+  vars:
+    inventory:
+      - name: install_docker_default
+        image: "chrismeyers/centos7"
+      - name: install_docker_latest
+        image: "chrismeyers/centos7"
+  roles:
+    - { role: provision_docker, provision_docker_privileged: "{{ true }}", provision_docker_inventory: "{{ inventory }}", become: true, become_user: "root" }
+
+- name: Run Docker install test (default values)
+  hosts: install_docker_default
+  roles:
+    - { role: install-docker, testing: true }
+
+  tasks:
+    - command: rpm --query docker-engine --queryformat '%{VERSION}'
+      register: install_docker_version
+
+    - assert:
+        that:
+          - "docker_engine_version in install_docker_version.stdout"
+
+- name: Run Docker install test (latest version)
+  hosts: install_docker_latest
+  roles:
+    - { role: install-docker, testing: true, docker_engine_version: "latest" }


### PR DESCRIPTION
Need to allow for version of Docker engine being installed to be
specified. This change adds a default version as well and pins it to
what is currently passing preflight checks for kubeadm.

Closes #1