### PR TITLE
[hotfix] Utilize user correctly for groups

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,8 @@
 - name: Add ansible_user to 'docker' group
   user:
     name: "{{ ansible_user }}"
-    group: docker
+    groups: docker
+    append: yes
 
 - name: Restart registries service
   systemd:


### PR DESCRIPTION
When you just use the group argument with the user module, that just sets
a primary group. Instead, a list of groups should utilize the groups argument.
Additionally, add the append: yes argument and setting so that we don't
just override the list of groups for the user.