### PR TITLE
Allows non-root user to use Docker during run

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ latest Docker version, or (optionally) a pinned Docker version.
 Primarily used in
 [kube-centos-ansible](https://github.com/redhat-nfvpe/kube-centos-ansible).
 
+> **WARNING**
+>
+> This role will setup the `ansible_user` in the `docker` group, allowing for
+> Docker to be run as a non-root user. Unfortunately, that effectively makes
+> the non-root user a root user, which could potentially have security
+> implications in your environment.
+
 ## Role Variables
 
 Available variables listed below along with their default values (see

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
     name: "{{ ansible_user }}"
     groups: docker
     append: yes
+  register: user_to_docker_group
 
 - name: Restart registries service
   systemd:
@@ -66,3 +67,9 @@
     state: started
     enabled: yes
   when: testing is not defined and not testing
+
+- name: Reset SSH connection so groups are available
+  shell: sleep 1; pkill -u {{ ansible_user }} sshd
+  async: 3
+  poll: 2
+  when: user_to_docker_group.changed


### PR DESCRIPTION
When using the install-docker role, you're unable to consume Docker commands from
a non-root user during the same run. This change resets the SSH connection to allow
for the non-root user to have their groups updated in the shell, allowing for execution
of Docker commands during the same run.

Only resets the connection when the docker group has been added to the user during
that run.

Closes #6