### PR TITLE
[docker-ce][refactor] Adds option to allow Docker-CE to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,38 @@ Primarily used in
 > the non-root user a root user, which could potentially have security
 > implications in your environment.
 
+## Selecting Docker versions
+
+This is optimized primarily for CentOS, and likely works with Fedora. However,
+you have two options generally for installed Docker.
+
+* RPMs installed from official CentOS repositories.
+* Installation from Docker-CE RPM repos.
+
+You may specify the variable `docker_repo_type` as either `ce` or `os`. The 
+value of `os` is default, and stands for "operating system default", `ce` is
+for "community edition" referring to Docker's nomenclature of their product.
+
+For example, to override the default `os` value, reference the role as:
+
+```
+- { role: ansible-role-install-docker, docker_repo_type: "ce" }
+```
+
 ## Role Variables
 
 Available variables listed below along with their default values (see
 `defaults/main.yml`):
 
+Select the repository from which to install Docker.
+
+```
+docker_repo_type: "os"
+```
+
 Set the package base name. If installing from another repository, may need to
 change the base name to something like `docker-engine`.
+
 ```
 docker_package_base_name: docker
 ```
@@ -48,6 +73,12 @@ A list of Docker registries to block.
 
 ```
 docker_block_registries: []
+```
+
+An option to disable allowing docker for a non-root user:
+
+```
+docker_non_root_user: false
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 docker_package_version: latest
 docker_package_base_name: docker
+docker_non_root_user: true
+# valid values: os or ce
+docker_repo_type: os

--- a/tasks/docker_ce.yml
+++ b/tasks/docker_ce.yml
@@ -1,0 +1,12 @@
+---
+- name: Add Docker-CE stable repo
+  yum_repository:
+    name: docker-ce-stable
+    description: Docker CE Stable Repo
+    baseurl: https://download.docker.com/linux/centos/7/$basearch/stable
+    gpgkey: https://download.docker.com/linux/centos/gpg
+    gpgcheck: yes
+
+- name: Setup base name fact
+  set_fact:
+    docker_package_base_name: docker-ce

--- a/tasks/docker_centos.yml
+++ b/tasks/docker_centos.yml
@@ -1,0 +1,46 @@
+---
+- name: Install primary deps (for ansible)
+  package:
+    name: libselinux-python
+    state: present
+  when: testing is not defined and not testing
+
+- name: Setup Docker name and version to install
+  set_fact:
+    docker_package: "{% if docker_package_version == 'latest' %}{{ docker_package_base_name }}{% else %}{{ docker_package_base_name }}-{{ docker_package_version }}{% endif %}"
+
+- name: Install Docker and dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ docker_package }}"
+    - atomic-registries
+
+- name: Get installed Docker version
+  command: rpm --query {{ docker_package }} --queryformat '%{VERSION}'
+  register: installed_docker_version
+
+# Updates Docker service file to allow for registries. Not necessary once
+# version 1.13.x is available.
+# Ref: http://pkgs.fedoraproject.org/cgit/rpms/docker.git/plain/docker.service.centos?id=957fa278aa5f152da2a588a1a28f650ba7fe807d
+# Ref: https://github.com/projectatomic/docker/issues/285
+- name: Update Docker systemd unit file
+  copy:
+    src: docker.centos.service
+    dest: /usr/lib/systemd/system/docker.service
+  when: >
+    (installed_docker_version.stdout | version_compare('1.13', '<')) and
+    docker_repo_type == 'os'
+  register: docker_service_file
+
+- name: Setup registry data
+  template:
+    src: etc_containers_registries.conf.j2
+    dest: /etc/containers/registries.conf
+  register: registry_data
+
+- name: Reload systemd units
+  systemd:
+    daemon_reload: yes
+  when: docker_service_file.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,75 +1,16 @@
 ---
-- name: Install primary deps (for ansible)
-  package:
-    name: libselinux-python
-    state: present
-  when: testing is not defined and not testing
 
-- name: Setup Docker name and version to install
-  set_fact:
-    docker_package: "{% if docker_package_version == 'latest' %}{{ docker_package_base_name }}{% else %}{{ docker_package_base_name }}-{{ docker_package_version }}{% endif %}"
+- name: Include Docker-CE setup
+  import_tasks: docker_ce.yml
+  when: docker_repo_type == 'ce'
 
-- name: Install Docker and dependencies
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "{{ docker_package }}"
-    - atomic-registries
+- name: Include CentOS docker
+  import_tasks: docker_centos.yml
 
-- name: Get installed Docker version
-  command: rpm --query {{ docker_package }} --queryformat '%{VERSION}'
-  register: installed_docker_version
+- name: Include User setup
+  import_tasks: user_setup.yml
+  when: docker_non_root_user
 
-# Updates Docker service file to allow for registries. Not necessary once
-# version 1.13.x is available.
-# Ref: http://pkgs.fedoraproject.org/cgit/rpms/docker.git/plain/docker.service.centos?id=957fa278aa5f152da2a588a1a28f650ba7fe807d
-# Ref: https://github.com/projectatomic/docker/issues/285
-- name: Update Docker systemd unit file
-  copy:
-    src: docker.centos.service
-    dest: /usr/lib/systemd/system/docker.service
-  when: installed_docker_version.stdout | version_compare('1.13', '<')
-  register: docker_service_file
-
-- name: Setup registry data
-  template:
-    src: etc_containers_registries.conf.j2
-    dest: /etc/containers/registries.conf
-  register: registry_data
-
-- name: Reload systemd units
-  systemd:
-    daemon_reload: yes
-  when: docker_service_file.changed
-
-- name: Add 'docker' group
-  group:
-    name: docker
-    state: present
-
-- name: Add ansible_user to 'docker' group
-  user:
-    name: "{{ ansible_user }}"
-    groups: docker
-    append: yes
-  register: user_to_docker_group
-
-- name: Restart registries service
-  systemd:
-    name: docker.service
-    state: restarted
-  when: registry_data.changed
-
-- name: Start and enable Docker service
-  systemd:
-    name: docker.service
-    state: started
-    enabled: yes
-  when: testing is not defined and not testing
-
-- name: Reset SSH connection so groups are available
-  shell: sleep 1; pkill -u {{ ansible_user }} sshd
-  async: 3
-  poll: 2
-  when: user_to_docker_group.changed
+- name: Start docker service
+  import_tasks: start_service.yml
+  when: not docker_non_root_user

--- a/tasks/start_service.yml
+++ b/tasks/start_service.yml
@@ -1,0 +1,13 @@
+---
+- name: Restart registries service
+  systemd:
+    name: docker.service
+    state: restarted
+  when: registry_data.changed
+
+- name: Start and enable Docker service
+  systemd:
+    name: docker.service
+    state: started
+    enabled: yes
+  when: testing is not defined and not testing

--- a/tasks/user_setup.yml
+++ b/tasks/user_setup.yml
@@ -1,0 +1,21 @@
+---
+- name: Add 'docker' group
+  group:
+    name: docker
+    state: present
+
+- name: Add ansible_user to 'docker' group
+  user:
+    name: "{{ ansible_user }}"
+    groups: docker
+    append: yes
+  register: user_to_docker_group
+
+- name: Start docker service
+  import_tasks: start_service.yml
+
+- name: Reset SSH connection so groups are available
+  shell: sleep 1; pkill -u {{ ansible_user }} sshd
+  async: 3
+  poll: 2
+  when: user_to_docker_group.changed


### PR DESCRIPTION
Main points:

* refactored main.yml into a "handler" (not ansible handler) to delegate to included tasks
* leverages existing variables
* also includes a method to skip installation as non-root

Example test playbook I was using:

```
---
- hosts: nodes
  tasks: []
  become: true
  become_user: root
  roles:
    - { role: ansible-role-install-docker, docker_repo_type: "ce" }
```

Fixes #9 
Fixes #8 