### PR TITLE
[tag_version] Tag Docker to 1.12.6-71.git3e8e77d.el7.centos.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_package_version: latest
+docker_package_version: 1.12.6-71.git3e8e77d.el7.centos.1
 docker_package_base_name: docker
 docker_non_root_user: true
 # valid values: os or ce


### PR DESCRIPTION
Issues with Docker 1.13 on CentOS 7.4 are causing a tagging
of Docker back to the last known working version.

Closes https://github.com/redhat-nfvpe/kube-ansible/issues/199