### PR TITLE
[hotfix] Installs dm_thin_pool kernel module

### DIFF
--- a/tasks/docker_centos.yml
+++ b/tasks/docker_centos.yml
@@ -5,6 +5,11 @@
     state: present
   when: testing is not defined and not testing
 
+- name: Validate thin_pool kernel module is loaded
+  modprobe:
+    name: dm_thin_pool
+    state: present
+
 - name: Setup Docker name and version to install
   set_fact:
     docker_package: "{% if docker_package_version == 'latest' %}{{ docker_package_base_name }}{% else %}{{ docker_package_base_name }}-{{ docker_package_version }}{% endif %}"


### PR DESCRIPTION
Makes sure the dm_thin_pool kernel module is loaded into memory so that
GlusterFS installation via Heketi will work.

Closes #13