### PR TITLE
Add docker_install_suppress_newgrp variable to skip newgrp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ docker_package_base_name: docker
 docker_non_root_user: true
 # valid values: os or ce
 docker_repo_type: os
+docker_install_suppress_newgrp: false
 ### if HTTP/HTTPS proxy is used specify proxy settings below
 ## if proxies are needed set them in proxy_env dictionary
 # !!!! NOTE ansible does not support https:// for https_proxy, only http://

--- a/tasks/user_setup.yml
+++ b/tasks/user_setup.yml
@@ -13,7 +13,7 @@
 
 - name: Load 'docker' group into the ansible_user
   command: newgrp docker
-  when: user_to_docker_group.changed
+  when: user_to_docker_group.changed and docker_install_suppress_newgrp|bool
 
 - name: Start docker service
   import_tasks: start_service.yml


### PR DESCRIPTION
Fix #21. With latest ansible, newgrp is stucked due to missing
reload ssh connection, however, ansible's PR (41126) prohibits to
call meta. In kube-ansible case, we do not need to do newgrp
because VMs is reloaded just after docker install for selinux,
so adding docker_install_suppress_newgrp to suppress newgrp.