### PR TITLE
Replace 'version_compare' filter  with 'version'

### DIFF
--- a/tasks/docker_centos.yml
+++ b/tasks/docker_centos.yml
@@ -37,7 +37,7 @@
     src: docker.centos.service
     dest: /usr/lib/systemd/system/docker.service
   when: >
-    (installed_docker_version.stdout | version_compare('1.13', '<')) and
+    (installed_docker_version.stdout is version('1.13', '<')) and
     docker_repo_type == 'os'
   register: docker_service_file
 


### PR DESCRIPTION
In ansible 2.5, 'version_compare' is changed to 'version'.
This fix is changes 'version_compare' to 'version'.

This is addressed in redhat-nfvpe/kube-ansible/issues/304